### PR TITLE
chore: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.php linguist-language=PHP


### PR DESCRIPTION
adiciona .gitattributes para que o GitHub possa reconhecer arquivos .php como linguagem PHP invés de Hack.